### PR TITLE
Replace vlc package with dependencies but Qt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN	add-apt-repository -y ppa:iconnor/zoneminder-$ZM_VERS && \
 	apt-get -y install ssmtp mailutils net-tools wget sudo make cmake gcc && \
 	apt-get -y install php$PHP_VERS php$PHP_VERS-fpm libapache2-mod-php$PHP_VERS php$PHP_VERS-mysql php$PHP_VERS-gd && \
 	apt-get -y install libcrypt-mysql-perl libyaml-perl libjson-perl libavutil-dev ffmpeg && \
-	apt-get -y install --no-install-recommends libvlc-dev libvlccore-dev vlc && \
+	apt-get -y install --no-install-recommends libvlc-dev libvlccore-dev vlc-bin vlc-plugin-base vlc-plugin-video-output && \
 	apt-get -y install zoneminder
 	
 FROM build1 as build2


### PR DESCRIPTION
Replace vlc package with its dependencies vlc-bin, vlc-plugin-base and vlc-plugin-video-output, in order to avoid installing useless packages dependient on vlc-plugin-qt.