### PR TITLE
add library libgeos-dev to install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN	rm /etc/mysql/my.cnf && \
 
 FROM build2 as build3
 RUN	apt-get -y install python3-pip && \
-	apt-get -y install libopenblas-dev liblapack-dev libblas-dev && \
+	apt-get -y install libopenblas-dev liblapack-dev libblas-dev libgeos-dev && \
 	pip3 install future && \
 	pip3 install /root/zmeventnotification && \
 	pip3 install face_recognition && \


### PR DESCRIPTION
Please consider this change - I attempted to build the docker image myself using the multi-arch buildx way, as I wanted to try to run this image on a Raspberry PI.

The [install docs](https://zmeventnotification.readthedocs.io/en/latest/guides/hooks.html#automatic-install) do say that it is needed, maybe it is possible that the phusion/baseimage for arm64 does not include the library?

I would think that it would not be harmful to include this library by default and if it is already installed then it will just be skipped.

Thanks for your consideration!