### PR TITLE
uncomment mutex file line in apache conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,7 @@ RUN	apt-get -y install python3-pip && \
 FROM build3 as build4
 RUN	cd /root && \
 	chown -R www-data:www-data /usr/share/zoneminder/ && \
+	sed -i "s|^#Mutex file|Mutex file|" /etc/apache2/apache2.conf && \
 	echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
 	sed -i "s|^;date.timezone =.*|date.timezone = ${TZ}|" /etc/php/$PHP_VERS/apache2/php.ini && \
 	service mysql start && \


### PR DESCRIPTION
While building this image myself, I noticed that during the phase that starts up the services, the apache2 service was not starting up. The image build does seem to complete without this impacting anything negatively, but for completeness sake I investigated the root cause and found that apache2 does not seem to be reading the configuration properly and was trying to use the wrong mutex type.

This change fixes the problem so that apache2 is able to start up. Oddly, but the time that the docker image is deployed, this change is not required and apache2 starts up just fine.

```
#13 [build5 1/1] RUN    MV /root/zoneminder /etc/init.d/zoneminder &&   chmod +x /etc/init.d/zoneminder &&      service mysql restart &&        sleep 5 &&  service apache2 start &&        service zoneminder start
#13 sha256:385dc180de05d9c25f80beace00244139420e1bac82568df973f45add8194e88
#13 0.666  * Stopping MariaDB database server mysqld
#13 1.091    ...done.
#13 1.420  * Starting MariaDB database server mysqld
#13 5.618    ...done.
#13 10.91  * Starting Apache httpd web server apache2
#13 11.70 [Sun Jul 11 21:59:03.196924 2021] [core:emerg] [pid 800] (95)Operation not supported: AH00023: Couldn't create the mpm-accept mutex
#13 11.70 (95)Operation not supported: could not create accept mutex
#13 11.70 AH00015: Unable to open logs
#13 11.72 Action 'start' failed.
#13 11.72 The Apache error log may have more information.
#13 11.72  *
#13 11.84 /usr/bin/env: ‘/etc/init.d/zoneminder’: No such file or directory
#13 ERROR: executor failed running [/bin/sh -c mv /root/zoneminder /etc/init.d/zoneminder &&    chmod +x /etc/init.d/zoneminder &&      service mysql restart &&    sleep 5 &&      service apache2 start &&        service zoneminder start]: exit code: 127
------
 > [build5 1/1] RUN     MV /root/zoneminder /etc/init.d/zoneminder &&   chmod +x /etc/init.d/zoneminder &&      service mysql restart &&        sleep 5 &&  service apache2 start &&        service zoneminder start:
------
```

It is worth calling out that I encountered this error while building an arm64 image using buildx, so that problem may only be present in that build flow.

Please consider whether it makes sense to include this change. Thanks!